### PR TITLE
Restore Plone 5.2 / Plone 6 compatibility for Scripts/Styles viewlets

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 12.6-dev0 - (unreleased)
 ---------------------------
+* Fix: Restore Plone 5.2 / Plone 6 compatibility for Scripts/Styles viewlets
+  (try scripts/styles modules, fall back to resource)
+  [valipod]
 
 12.5 - (2026-05-19)
 ---------------------------

--- a/eea/volto/policy/cmfplone_compat.py
+++ b/eea/volto/policy/cmfplone_compat.py
@@ -1,0 +1,8 @@
+try:
+    from Products.CMFPlone.resources.browser.scripts import ScriptsView
+    from Products.CMFPlone.resources.browser.styles import StylesView
+except ImportError:
+    from Products.CMFPlone.resources.browser.resource import ScriptsView
+    from Products.CMFPlone.resources.browser.resource import StylesView
+
+__all__ = ("ScriptsView", "StylesView")

--- a/eea/volto/policy/viewlets.zcml
+++ b/eea/volto/policy/viewlets.zcml
@@ -57,23 +57,21 @@
       permission="zope.Public"
       />
 
-  <configure package="Products.CMFPlone.resources.browser">
-    <browser:viewlet
-        name="plone.resourceregistries.scripts"
-        layer="eea.volto.policy.interfaces.IEeaVoltoPolicyLayer"
-        manager="plone.app.layout.viewlets.interfaces.IScripts"
-        class=".scripts.ScriptsView"
-        permission="zope.Public"
-        />
+  <browser:viewlet
+      name="plone.resourceregistries.scripts"
+      layer=".interfaces.IEeaVoltoPolicyLayer"
+      manager="plone.app.layout.viewlets.interfaces.IScripts"
+      class=".cmfplone_compat.ScriptsView"
+      permission="zope.Public"
+      />
 
-    <browser:viewlet
-        name="plone.resourceregistries.styles"
-        layer="eea.volto.policy.interfaces.IEeaVoltoPolicyLayer"
-        manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
-        class=".styles.StylesView"
-        permission="zope.Public"
-        />
-  </configure>
+  <browser:viewlet
+      name="plone.resourceregistries.styles"
+      layer=".interfaces.IEeaVoltoPolicyLayer"
+      manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
+      class=".cmfplone_compat.StylesView"
+      permission="zope.Public"
+      />
 
   <configure package="plone.app.layout.viewlets">
     <browser:viewlet


### PR DESCRIPTION
- https://github.com/plone/Products.CMFPlone/commit/fa73ad8 moves `ScriptsView` and `StylesView` to `Products/CMFPlone/resources/browser/scripts.py` and `styles.py`
BUT
- https://github.com/plone/Products.CMFPlone/commit/23c4fdb Removes `scripts.py` and `styles.py` folds their contents into resource.py

so...